### PR TITLE
Sonance fixes

### DIFF
--- a/custom_components/xantech/const.py
+++ b/custom_components/xantech/const.py
@@ -36,6 +36,18 @@ AMP_TYPE_ZPR68: Final = 'zpr68-10'
 # sonance6: Sonance C4630 SE (6-zone), 875D MKII (4-zone)
 AMP_TYPE_SONANCE6: Final = 'sonance6'
 
+# Sonance6 volume range: below 40 is inaudibly quiet, physical max is 60
+SONANCE6_MIN_VOLUME: Final = 40
+SONANCE6_MAX_VOLUME: Final = 60
+
+# Sonance6 EQ ranges (signed)
+SONANCE6_MIN_BASS: Final = -8
+SONANCE6_MAX_BASS: Final = 8
+SONANCE6_MIN_TREBLE: Final = -8
+SONANCE6_MAX_TREBLE: Final = 8
+SONANCE6_MIN_BALANCE: Final = -10
+SONANCE6_MAX_BALANCE: Final = 10
+
 SUPPORTED_AMP_TYPES: Final[list[str]] = [
     AMP_TYPE_XANTECH8,
     AMP_TYPE_MONOPRICE6,

--- a/custom_components/xantech/media_player.py
+++ b/custom_components/xantech/media_player.py
@@ -16,9 +16,12 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
+    AMP_TYPE_SONANCE6,
     CONF_ZONES,
     DOMAIN,
     MAX_VOLUME,
+    SONANCE6_MAX_VOLUME,
+    SONANCE6_MIN_VOLUME,
 )
 from .coordinator import XantechCoordinator
 
@@ -46,6 +49,7 @@ async def async_setup_entry(
     data = entry.runtime_data
     coordinator = data.coordinator
     sources = data.sources
+    amp_type = data.amp_type
 
     zones_config = entry.data.get(CONF_ZONES, {})
 
@@ -62,6 +66,7 @@ async def async_setup_entry(
                 zone_id=zone_id,
                 zone_name=zone_name,
                 sources=sources,
+                amp_type=amp_type,
             )
         )
 
@@ -82,12 +87,14 @@ class ZoneMediaPlayer(CoordinatorEntity[XantechCoordinator], MediaPlayerEntity):
         zone_id: int,
         zone_name: str,
         sources: dict[int, str],
+        amp_type: str,
     ) -> None:
         """Initialize the zone media player."""
         super().__init__(coordinator)
 
         self._zone_id = zone_id
         self._zone_name = zone_name
+        self._amp_type = amp_type
 
         # source mappings
         self._source_id_to_name = sources
@@ -173,12 +180,27 @@ class ZoneMediaPlayer(CoordinatorEntity[XantechCoordinator], MediaPlayerEntity):
         volume = self._zone_status.get('volume')
         if volume is None:
             return None
-        return volume / MAX_VOLUME
+        vol_range = self._max_volume - self._min_volume
+        return (volume - self._min_volume) / vol_range
 
     @property
     def is_volume_muted(self) -> bool:
         """Boolean if volume is currently muted."""
         return self._zone_status.get('mute', False)
+
+    @property
+    def _max_volume(self) -> int:
+        """Hardware maximum volume for this amp type."""
+        if self._amp_type == AMP_TYPE_SONANCE6:
+            return SONANCE6_MAX_VOLUME
+        return MAX_VOLUME
+
+    @property
+    def _min_volume(self) -> int:
+        """Hardware minimum usable volume for this amp type."""
+        if self._amp_type == AMP_TYPE_SONANCE6:
+            return SONANCE6_MIN_VOLUME
+        return 0
 
     @property
     def source(self) -> str | None:
@@ -237,7 +259,8 @@ class ZoneMediaPlayer(CoordinatorEntity[XantechCoordinator], MediaPlayerEntity):
 
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0-1.0."""
-        amp_volume = int(volume * MAX_VOLUME)
+        vol_range = self._max_volume - self._min_volume
+        amp_volume = int(volume * vol_range) + self._min_volume
         LOG.debug('Setting zone %d volume to %d', self._zone_id, amp_volume)
         self._set_optimistic(volume=amp_volume)
         try:
@@ -250,7 +273,7 @@ class ZoneMediaPlayer(CoordinatorEntity[XantechCoordinator], MediaPlayerEntity):
         volume = self._zone_status.get('volume')
         if volume is None:
             return
-        new_volume = min(volume + 1, MAX_VOLUME)
+        new_volume = min(volume + 1, self._max_volume)
         self._set_optimistic(volume=new_volume)
         try:
             await self.coordinator.async_set_zone_volume(self._zone_id, new_volume)
@@ -262,7 +285,7 @@ class ZoneMediaPlayer(CoordinatorEntity[XantechCoordinator], MediaPlayerEntity):
         volume = self._zone_status.get('volume')
         if volume is None:
             return
-        new_volume = max(volume - 1, 0)
+        new_volume = max(volume - 1, self._min_volume)
         self._set_optimistic(volume=new_volume)
         try:
             await self.coordinator.async_set_zone_volume(self._zone_id, new_volume)

--- a/custom_components/xantech/number.py
+++ b/custom_components/xantech/number.py
@@ -13,12 +13,19 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from pyxantech import get_device_config
 
 from .const import (
+    AMP_TYPE_SONANCE6,
     CONF_ENABLE_AUDIO_CONTROLS,
     CONF_ZONES,
     DEFAULT_MAX_BALANCE,
     DEFAULT_MAX_BASS,
     DEFAULT_MAX_TREBLE,
     DOMAIN,
+    SONANCE6_MAX_BALANCE,
+    SONANCE6_MAX_BASS,
+    SONANCE6_MAX_TREBLE,
+    SONANCE6_MIN_BALANCE,
+    SONANCE6_MIN_BASS,
+    SONANCE6_MIN_TREBLE,
 )
 from .coordinator import XantechCoordinator
 
@@ -58,19 +65,18 @@ async def async_setup_entry(
         LOG.debug('Device %s does not support any tone controls', amp_type)
         return
 
-    # get device-specific limits from pyxantech config
-    max_bass = (
-        get_device_config(amp_type, 'max_bass', log_missing=False)
-        or DEFAULT_MAX_BASS
-    )
-    max_treble = (
-        get_device_config(amp_type, 'max_treble', log_missing=False)
-        or DEFAULT_MAX_TREBLE
-    )
-    max_balance = (
-        get_device_config(amp_type, 'max_balance', log_missing=False)
-        or DEFAULT_MAX_BALANCE
-    )
+    # get device-specific limits; Sonance6 uses signed ranges
+    if amp_type == AMP_TYPE_SONANCE6:
+        min_bass, max_bass = SONANCE6_MIN_BASS, SONANCE6_MAX_BASS
+        min_treble, max_treble = SONANCE6_MIN_TREBLE, SONANCE6_MAX_TREBLE
+        min_balance, max_balance = SONANCE6_MIN_BALANCE, SONANCE6_MAX_BALANCE
+    else:
+        min_bass = 0
+        max_bass = get_device_config(amp_type, 'max_bass', log_missing=False) or DEFAULT_MAX_BASS
+        min_treble = 0
+        max_treble = get_device_config(amp_type, 'max_treble', log_missing=False) or DEFAULT_MAX_TREBLE
+        min_balance = 0
+        max_balance = get_device_config(amp_type, 'max_balance', log_missing=False) or DEFAULT_MAX_BALANCE
 
     zones_config = entry.data.get(CONF_ZONES, {})
 
@@ -88,6 +94,7 @@ async def async_setup_entry(
                     entry=entry,
                     zone_id=zone_id,
                     zone_name=zone_name,
+                    min_value=min_bass,
                     max_value=max_bass,
                 )
             )
@@ -98,6 +105,7 @@ async def async_setup_entry(
                     entry=entry,
                     zone_id=zone_id,
                     zone_name=zone_name,
+                    min_value=min_treble,
                     max_value=max_treble,
                 )
             )
@@ -108,6 +116,7 @@ async def async_setup_entry(
                     entry=entry,
                     zone_id=zone_id,
                     zone_name=zone_name,
+                    min_value=min_balance,
                     max_value=max_balance,
                 )
             )
@@ -125,7 +134,6 @@ class ZoneAudioControlNumber(CoordinatorEntity[XantechCoordinator], NumberEntity
 
     _attr_has_entity_name = True
     _attr_mode = NumberMode.SLIDER
-    _attr_native_min_value = 0
     _attr_native_step = 1
 
     def __init__(
@@ -136,6 +144,7 @@ class ZoneAudioControlNumber(CoordinatorEntity[XantechCoordinator], NumberEntity
         zone_name: str,
         control_key: str,
         name_suffix: str,
+        min_value: int,
         max_value: int,
     ) -> None:
         """Initialize the audio control number entity."""
@@ -146,7 +155,8 @@ class ZoneAudioControlNumber(CoordinatorEntity[XantechCoordinator], NumberEntity
         self._control_key = control_key
         self._entry = entry
 
-        # set device-specific max value
+        # set device-specific min/max values
+        self._attr_native_min_value = float(min_value)
         self._attr_native_max_value = float(max_value)
 
         # optimistic state tracking
@@ -216,6 +226,7 @@ class ZoneBassNumber(ZoneAudioControlNumber):
         entry: XantechConfigEntry,
         zone_id: int,
         zone_name: str,
+        min_value: int,
         max_value: int,
     ) -> None:
         """Initialize the bass control entity."""
@@ -226,6 +237,7 @@ class ZoneBassNumber(ZoneAudioControlNumber):
             zone_name=zone_name,
             control_key='bass',
             name_suffix='Bass',
+            min_value=min_value,
             max_value=max_value,
         )
 
@@ -251,6 +263,7 @@ class ZoneTrebleNumber(ZoneAudioControlNumber):
         entry: XantechConfigEntry,
         zone_id: int,
         zone_name: str,
+        min_value: int,
         max_value: int,
     ) -> None:
         """Initialize the treble control entity."""
@@ -261,6 +274,7 @@ class ZoneTrebleNumber(ZoneAudioControlNumber):
             zone_name=zone_name,
             control_key='treble',
             name_suffix='Treble',
+            min_value=min_value,
             max_value=max_value,
         )
 
@@ -286,6 +300,7 @@ class ZoneBalanceNumber(ZoneAudioControlNumber):
         entry: XantechConfigEntry,
         zone_id: int,
         zone_name: str,
+        min_value: int,
         max_value: int,
     ) -> None:
         """Initialize the balance control entity."""
@@ -296,6 +311,7 @@ class ZoneBalanceNumber(ZoneAudioControlNumber):
             zone_name=zone_name,
             control_key='balance',
             name_suffix='Balance',
+            min_value=min_value,
             max_value=max_value,
         )
 


### PR DESCRIPTION
## Sonance C4630 SE: hardware volume range and signed EQ control

Adds support for the Sonance C4630 SE (6-zone) and 875D MKII (4-zone)
amplifiers, which have a non-standard volume range and signed EQ values.

Depends on pyxantech `sonance-fixes` branch (or >=0.10.8 once released)
for the protocol-level fixes (multi-query zone status, signed EQ commands,
corrected response regex).

### Changes

**`const.py`**

Add hardware-specific constants for `sonance6`:

- `SONANCE6_MIN_VOLUME = 40`, `SONANCE6_MAX_VOLUME = 60` — the usable
  volume range. Values below 40 are inaudibly quiet on this hardware;
  the physical maximum is 60.
- `SONANCE6_MIN/MAX_BASS` (−8..+8), `SONANCE6_MIN/MAX_TREBLE` (−8..+8),
  `SONANCE6_MIN/MAX_BALANCE` (−10..+10) — signed EQ ranges.

**`media_player.py`**

- Pass `amp_type` through `async_setup_entry` into `ZoneMediaPlayer`.
- Add `_min_volume` / `_max_volume` properties that dispatch on
  `AMP_TYPE_SONANCE6`; all other types return `0` / `MAX_VOLUME` as
  before.
- Update `volume_level`, `async_set_volume_level`, `async_volume_up`,
  `async_volume_down` to use `_min_volume` / `_max_volume` so the HA
  0–1 range maps correctly to the hardware 40–60 range.

**`number.py`**

- Add `min_value` parameter to `ZoneAudioControlNumber` and all
  subclasses (was always `0` before via `_attr_native_min_value = 0`).
- For `sonance6`, use the signed EQ constants as slider min/max.
  All other amp types retain `min=0` and device-config-derived max.

### Affected hardware

- Sonance C4630 SE (6-zone) — tested
- Sonance 875D MKII (4-zone, same protocol — unverified)

All other amp types are unaffected: the `amp_type` dispatch only
changes behaviour for `AMP_TYPE_SONANCE6 = 'sonance6'`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Sonance6 amplifiers with device-specific volume and EQ control ranges.
  * Volume control now adapts to each amplifier's supported range.
  * Bass, treble, and balance controls now support negative values on compatible devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->