### PR TITLE
sonance6: fix volume clamping, serial flooding, and stale zone data

### DIFF
--- a/custom_components/xantech/coordinator.py
+++ b/custom_components/xantech/coordinator.py
@@ -48,6 +48,8 @@ class XantechCoordinator(DataUpdateCoordinator[dict[int, dict[str, Any]]]):
         self.zone_ids = zone_ids
         self._consecutive_errors = 0
         self._max_consecutive_errors = 5
+        self._zone_miss_count: dict[int, int] = {z: 0 for z in zone_ids}
+        self._zone_miss_warn_threshold = 5
 
     async def _async_update_data(self) -> dict[int, dict[str, Any]]:
         """Fetch data from the amplifier for all zones.
@@ -55,24 +57,61 @@ class XantechCoordinator(DataUpdateCoordinator[dict[int, dict[str, Any]]]):
         Returns:
             Dictionary mapping zone_id to zone status dict
         """
-        zone_statuses: dict[int, dict[str, Any]] = {}
+        # Start from previous data so zones that fail to poll this cycle
+        # keep their last known state rather than disappearing entirely.
+        zone_statuses: dict[int, dict[str, Any]] = dict(self.data or {})
 
         try:
+            zone_errors = 0
             for zone_id in self.zone_ids:
                 try:
                     status = await self.amp.zone_status(zone_id)
                     if status:
-                        zone_statuses[zone_id] = status
+                        # Merge returned fields into previous state. status may be
+                        # partial (only matched queries) so unmatched fields keep
+                        # their last known values rather than reverting to defaults.
+                        prev = zone_statuses.get(zone_id, {})
+                        zone_statuses[zone_id] = {**prev, **status}
+                        self._zone_miss_count[zone_id] = 0
                     else:
-                        LOG.debug('No status returned for zone %d', zone_id)
+                        self._zone_miss_count[zone_id] = (
+                            self._zone_miss_count.get(zone_id, 0) + 1
+                        )
+                        if (
+                            self._zone_miss_count[zone_id]
+                            >= self._zone_miss_warn_threshold
+                        ):
+                            LOG.warning(
+                                'Zone %d has returned no status for %d consecutive'
+                                ' polls; data may be stale',
+                                zone_id,
+                                self._zone_miss_count[zone_id],
+                            )
+                        else:
+                            LOG.debug(
+                                'No status returned for zone %d,'
+                                ' keeping previous state',
+                                zone_id,
+                            )
                 except Exception:
                     LOG.warning(
                         'Failed to get status for zone %d', zone_id, exc_info=True
                     )
-                    # continue with other zones even if one fails
+                    zone_errors += 1
 
-            # reset error counter on success
-            self._consecutive_errors = 0
+            if zone_errors:
+                self._consecutive_errors += 1
+                if self._consecutive_errors >= self._max_consecutive_errors:
+                    LOG.error(
+                        'Failed to update %s: %d/%d zones errored for %d'
+                        ' consecutive cycles',
+                        self.amp_name,
+                        zone_errors,
+                        len(self.zone_ids),
+                        self._consecutive_errors,
+                    )
+            else:
+                self._consecutive_errors = 0
 
             LOG.debug('Updated %d zones for %s', len(zone_statuses), self.amp_name)
             return zone_statuses

--- a/custom_components/xantech/coordinator.py
+++ b/custom_components/xantech/coordinator.py
@@ -94,7 +94,6 @@ class XantechCoordinator(DataUpdateCoordinator[dict[int, dict[str, Any]]]):
         """Set power state for a zone."""
         try:
             await self.amp.set_power(zone_id, power)
-            await self.async_request_refresh()
         except Exception:
             LOG.exception('Failed to set power for zone %d', zone_id)
             raise
@@ -103,7 +102,6 @@ class XantechCoordinator(DataUpdateCoordinator[dict[int, dict[str, Any]]]):
         """Set source for a zone."""
         try:
             await self.amp.set_source(zone_id, source_id)
-            await self.async_request_refresh()
         except Exception:
             LOG.exception('Failed to set source for zone %d', zone_id)
             raise
@@ -112,7 +110,6 @@ class XantechCoordinator(DataUpdateCoordinator[dict[int, dict[str, Any]]]):
         """Set volume for a zone (0-38 scale)."""
         try:
             await self.amp.set_volume(zone_id, volume)
-            await self.async_request_refresh()
         except Exception:
             LOG.exception('Failed to set volume for zone %d', zone_id)
             raise
@@ -121,7 +118,6 @@ class XantechCoordinator(DataUpdateCoordinator[dict[int, dict[str, Any]]]):
         """Set mute state for a zone."""
         try:
             await self.amp.set_mute(zone_id, mute)
-            await self.async_request_refresh()
         except Exception:
             LOG.exception('Failed to set mute for zone %d', zone_id)
             raise
@@ -130,7 +126,6 @@ class XantechCoordinator(DataUpdateCoordinator[dict[int, dict[str, Any]]]):
         """Set bass level for a zone (0-14, where 7 is neutral)."""
         try:
             await self.amp.set_bass(zone_id, bass)
-            await self.async_request_refresh()
         except Exception:
             LOG.exception('Failed to set bass for zone %d', zone_id)
             raise
@@ -139,7 +134,6 @@ class XantechCoordinator(DataUpdateCoordinator[dict[int, dict[str, Any]]]):
         """Set treble level for a zone (0-14, where 7 is neutral)."""
         try:
             await self.amp.set_treble(zone_id, treble)
-            await self.async_request_refresh()
         except Exception:
             LOG.exception('Failed to set treble for zone %d', zone_id)
             raise
@@ -148,7 +142,6 @@ class XantechCoordinator(DataUpdateCoordinator[dict[int, dict[str, Any]]]):
         """Set balance for a zone (0-20, where 10 is center)."""
         try:
             await self.amp.set_balance(zone_id, balance)
-            await self.async_request_refresh()
         except Exception:
             LOG.exception('Failed to set balance for zone %d', zone_id)
             raise

--- a/custom_components/xantech/media_player.py
+++ b/custom_components/xantech/media_player.py
@@ -181,7 +181,7 @@ class ZoneMediaPlayer(CoordinatorEntity[XantechCoordinator], MediaPlayerEntity):
         if volume is None:
             return None
         vol_range = self._max_volume - self._min_volume
-        return (volume - self._min_volume) / vol_range
+        return max(0.0, min(1.0, (volume - self._min_volume) / vol_range))
 
     @property
     def is_volume_muted(self) -> bool:


### PR DESCRIPTION
Three fixes for the Sonance C4630 SE integration, found during hardware
testing after PR #20 was merged.

## Changes

**`volume_level` clamping**
On fresh power-on the amp reports raw volume below `SONANCE6_MIN_VOLUME`,
producing a negative normalised value that breaks HA's volume slider.
Clamp the result to `[0.0, 1.0]`.

**Remove `async_request_refresh()` after set commands**
Every set command (volume, source, mute, EQ) was triggering an immediate
full poll of all zones — 7 queries × 6 zones = 42 serial round-trips at
9600 baud. Rapid clicks queued back-to-back 42-query bursts, saturating
the serial line and causing responses to interleave across zones.

The entities already implement optimistic state (`_set_optimistic` /
`_handle_coordinator_update`) so the UI updates instantly without a poll.
The periodic `scan_interval` handles eventual confirmation from the amp.

**Preserve previous zone data on failed poll**
When an unsolicited amp broadcast (e.g. a power-state notification
triggered by a source change) displaces a zone_status query response,
`zone_status()` returns `None` for that zone. The coordinator was
rebuilding `self.data` from scratch each cycle, so zones with failed
queries disappeared entirely — entities read `{}`, `power=None`, and
showed as OFF.

Start each poll from the previous data snapshot; zones that fail to
return status this cycle keep their last known state until the next
successful poll.

## Testing
Verified on Sonance C4630 SE (6 zones, TCP at 9600 baud) with rapid
source toggling across all zones.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Zone status is retained when intermittent updates fail.
  * Volume level is now clamped to the valid 0.0–1.0 range.

* **Improvements**
  * Polling is more resilient with smarter merging of partial updates and warnings for missed zone responses.
  * Zone controls respond faster by reducing automatic refresh cycles after user-initiated changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->